### PR TITLE
Quick Filter + Selected Total Size

### DIFF
--- a/ClipDock/Features/Home/RulePickers/MonthPickerView.swift
+++ b/ClipDock/Features/Home/RulePickers/MonthPickerView.swift
@@ -52,7 +52,7 @@ struct MonthPickerView: View {
             .navigationTitle(L10n.tr("Select by Month"))
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
-                    Button(L10n.tr("Done")) {
+                    Button(L10n.tr("Cancel")) {
                         onDone()
                     }
                 }

--- a/ClipDock/Features/Home/RulePickers/QuickFilterView.swift
+++ b/ClipDock/Features/Home/RulePickers/QuickFilterView.swift
@@ -1,0 +1,116 @@
+import SwiftUI
+
+struct QuickFilterView: View {
+    let summaries: [MonthSummary]
+    let isFetchingAllVideoSizes: Bool
+    let knownSizeCount: Int
+    let totalVideoCount: Int
+    let onCancel: () -> Void
+    let onApply: (Set<MonthKey>, Int) -> Void
+
+    @State private var selectedMonths: Set<MonthKey> = []
+    @State private var nText: String = ""
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section(L10n.tr("By Month")) {
+                    if summaries.isEmpty {
+                        Text(L10n.tr("Scan Videos"))
+                            .foregroundStyle(.secondary)
+                    } else {
+                        ForEach(summaries) { s in
+                            Button {
+                                toggleMonth(s.key)
+                            } label: {
+                                HStack {
+                                    VStack(alignment: .leading, spacing: 2) {
+                                        Text(s.key.displayText)
+                                        Text(verbatim: "\(s.count)")
+                                            .font(.caption)
+                                            .foregroundStyle(.secondary)
+                                    }
+                                    Spacer()
+                                    if selectedMonths.contains(s.key) {
+                                        Image(systemName: "checkmark")
+                                            .foregroundStyle(.tint)
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                Section(L10n.tr("Top N")) {
+                    TextField("N", text: $nText)
+                        .keyboardType(.numberPad)
+
+                    HStack(spacing: 10) {
+                        quickButton(20)
+                        quickButton(50)
+                        quickButton(100)
+                        Button(L10n.tr("Clear")) { nText = "" }
+                            .buttonStyle(.bordered)
+                            .tint(.secondary)
+                    }
+
+                    if isFetchingAllVideoSizes {
+                        HStack(spacing: 8) {
+                            ProgressView()
+                            Text(L10n.tr("Loading video sizes..."))
+                                .foregroundStyle(.secondary)
+                        }
+                    } else {
+                        Text(
+                            verbatim: L10n.tr(
+                                "Known sizes: %d/%d",
+                                knownSizeCount,
+                                totalVideoCount
+                            )
+                        )
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                    }
+
+                    Text(L10n.tr("Tip: Top-N selects the largest locally-sized videos. iCloud-only videos may be skipped."))
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .navigationTitle(L10n.tr("Quick Filter"))
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(L10n.tr("Cancel")) { onCancel() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(L10n.tr("Apply")) {
+                        onApply(selectedMonths, parsedN)
+                    }
+                    .disabled(!hasFilter)
+                }
+            }
+        }
+    }
+
+    private var parsedN: Int {
+        Int(nText.trimmingCharacters(in: .whitespacesAndNewlines)) ?? 0
+    }
+
+    private var hasFilter: Bool {
+        !selectedMonths.isEmpty || parsedN > 0
+    }
+
+    private func toggleMonth(_ key: MonthKey) {
+        if selectedMonths.contains(key) {
+            selectedMonths.remove(key)
+        } else {
+            selectedMonths.insert(key)
+        }
+    }
+
+    private func quickButton(_ v: Int) -> some View {
+        Button("\(v)") { nText = "\(v)" }
+            .buttonStyle(.bordered)
+    }
+}
+

--- a/ClipDock/Features/Home/RulePickers/TopNPickerView.swift
+++ b/ClipDock/Features/Home/RulePickers/TopNPickerView.swift
@@ -25,7 +25,7 @@ struct TopNPickerView: View {
                     if isFetchingAllVideoSizes {
                         HStack(spacing: 8) {
                             ProgressView()
-                            Text("Loading video sizes...")
+                            Text(L10n.tr("Loading video sizes..."))
                                 .foregroundStyle(.secondary)
                         }
                     } else {
@@ -48,7 +48,7 @@ struct TopNPickerView: View {
             .navigationTitle(L10n.tr("Select Top N"))
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
-                    Button(L10n.tr("Done")) {
+                    Button(L10n.tr("Cancel")) {
                         onDone()
                     }
                 }

--- a/ClipDock/Resources/en.lproj/Localizable.strings
+++ b/ClipDock/Resources/en.lproj/Localizable.strings
@@ -45,10 +45,13 @@
 
 "Select Videos" = "Select Videos";
 "Selected" = "Selected";
+"Selected Size" = "Selected Size";
 "Tip: tap a row to toggle selection." = "Tip: tap a row to toggle selection.";
 "Show Selected Only" = "Show Selected Only";
 "By Month..." = "By Month...";
 "Top N..." = "Top N...";
+"Quick Filter" = "Quick Filter";
+"By Month" = "By Month";
 "Apply" = "Apply";
 "Done" = "Done";
 "Select by Month" = "Select by Month";

--- a/ClipDock/Resources/zh-Hans.lproj/Localizable.strings
+++ b/ClipDock/Resources/zh-Hans.lproj/Localizable.strings
@@ -45,10 +45,13 @@
 
 "Select Videos" = "选择视频";
 "Selected" = "已选择";
+"Selected Size" = "已选择大小";
 "Tip: tap a row to toggle selection." = "提示：点击列表项可切换选择。";
 "Show Selected Only" = "仅显示已选择";
 "By Month..." = "按月份选择...";
 "Top N..." = "选择最大N...";
+"Quick Filter" = "快捷筛选";
+"By Month" = "按月份";
 "Apply" = "应用";
 "Done" = "完成";
 "Select by Month" = "按月份选择";

--- a/docs/releases/1.0/development.md
+++ b/docs/releases/1.0/development.md
@@ -180,3 +180,18 @@
    - size 排序模式下也会兜底触发全量 size 预取。
 4. 验证：
    - `xcodebuild test`（Simulator）：回归新增/更新 `HomeViewModelSortAndSizeTests` 覆盖扫描后全量 size 预取。
+
+### 2026-02-14 - 选择体验：快捷筛选 + 取消/应用 + 已选总大小
+1. 交付：
+   - 合并“按月份选择 / 最大 N”入口为单一入口 `Quick Filter（快捷筛选）`。
+   - 筛选弹窗按钮改为 `Cancel / Apply`；当未选择任何筛选条件时，`Apply` 不可用。
+   - 首页展示“已选视频总大小”（基于本地可得 size，iCloud-only 条目会导致部分未知）。
+   - `Clear` 在存在选择时视觉上更“亮”（启用态使用强调色）。
+2. 关键文件：
+   - `/Users/wenfeng/Documents/iphoneapp/ClipDock/Features/Home/HomeView.swift`
+   - `/Users/wenfeng/Documents/iphoneapp/ClipDock/Features/Home/RulePickers/QuickFilterView.swift`
+   - `/Users/wenfeng/Documents/iphoneapp/ClipDock/Features/Home/HomeViewModel.swift`
+   - `/Users/wenfeng/Documents/iphoneapp/ClipDock/Resources/en.lproj/Localizable.strings`
+   - `/Users/wenfeng/Documents/iphoneapp/ClipDock/Resources/zh-Hans.lproj/Localizable.strings`
+3. 验证：
+   - `xcodebuild test`（Simulator）：16 tests / 0 failure。


### PR DESCRIPTION
Implements issues #3 #4 #5 #6.\n\nChanges:\n- Add Quick Filter sheet (month + Top-N) with Cancel/Apply (Apply enabled only when filter set).\n- Show selected total size (best-effort local sizes) and known count.\n- Clear button appears active only when selection exists.\n- Month/TopN pickers updated to Cancel/Apply for consistency.\n\nVerification:\n- xcodebuild test (iPhone 16 simulator) passed.