### PR TITLE
Quick Filter: Group Months by Year

### DIFF
--- a/ClipDock/Features/Home/RulePickers/MonthSummaryGrouper.swift
+++ b/ClipDock/Features/Home/RulePickers/MonthSummaryGrouper.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+struct MonthYearGroup: Identifiable, Hashable {
+    let year: Int
+    let months: [MonthSummary] // key: .yearMonth only, sorted desc by month
+
+    var id: Int { year }
+
+    var totalCount: Int {
+        months.reduce(0) { $0 + $1.count }
+    }
+}
+
+enum MonthSummaryGrouper {
+    static func group(_ summaries: [MonthSummary]) -> (yearGroups: [MonthYearGroup], unknown: MonthSummary?) {
+        var byYear: [Int: [MonthSummary]] = [:]
+        var unknown: MonthSummary?
+
+        for s in summaries {
+            switch s.key {
+            case .unknown:
+                unknown = s
+            case let .yearMonth(year, _):
+                byYear[year, default: []].append(s)
+            }
+        }
+
+        let years = byYear.keys.sorted(by: >)
+        let groups: [MonthYearGroup] = years.map { year in
+            let months = (byYear[year] ?? []).sorted { a, b in
+                switch (a.key, b.key) {
+                case let (.yearMonth(_, ma), .yearMonth(_, mb)):
+                    return ma > mb
+                default:
+                    return a.key > b.key
+                }
+            }
+            return MonthYearGroup(year: year, months: months)
+        }
+
+        return (groups, unknown)
+    }
+}
+

--- a/ClipDockTests/MonthSummaryGrouperTests.swift
+++ b/ClipDockTests/MonthSummaryGrouperTests.swift
@@ -1,0 +1,24 @@
+import XCTest
+@testable import ClipDock
+
+final class MonthSummaryGrouperTests: XCTestCase {
+    func testGroupBuildsYearHierarchyAndKeepsUnknown() {
+        var summaries: [MonthSummary] = []
+        // Build 6 years * 12 months = 72 month entries.
+        for year in 2020...2025 {
+            for month in 1...12 {
+                summaries.append(.init(key: .yearMonth(year: year, month: month), count: 1))
+            }
+        }
+        summaries.append(.init(key: .unknown, count: 9))
+
+        let out = MonthSummaryGrouper.group(summaries)
+
+        XCTAssertEqual(out.yearGroups.map(\.year), [2025, 2024, 2023, 2022, 2021, 2020])
+        XCTAssertEqual(out.yearGroups.first?.months.first?.key, .yearMonth(year: 2025, month: 12))
+        XCTAssertEqual(out.yearGroups.first?.months.last?.key, .yearMonth(year: 2025, month: 1))
+        XCTAssertEqual(out.unknown?.key, .unknown)
+        XCTAssertEqual(out.unknown?.count, 9)
+    }
+}
+


### PR DESCRIPTION
Fixes #9.\n\nAdds year -> month hierarchy (DisclosureGroup) to keep month list short, plus unit test for long lists.\n\nVerification:\n- xcodebuild test (iPhone 16 simulator) passed.